### PR TITLE
chore: remove npm package vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,7 @@
         "cacache": "17.1.3",
         "chokidar": "3.5.3",
         "copy-webpack-plugin": "11.0.0",
-        "critters": "0.0.19",
+        "critters": "0.0.20",
         "css-loader": "6.8.1",
         "esbuild-wasm": "0.17.19",
         "fast-glob": "3.2.12",
@@ -6628,9 +6628,9 @@
       }
     },
     "node_modules/critters": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/critters/-/critters-0.0.19.tgz",
-      "integrity": "sha512-Fm4ZAXsG0VzWy1U30rP4qxbaWGSsqXDgSupJW1OUJGDAs0KWC+j37v7p5a2kZ9BPJvhRzWm3be+Hc9WvQOBUOw==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/critters/-/critters-0.0.20.tgz",
+      "integrity": "sha512-CImNRorKOl5d8TWcnAz5n5izQ6HFsvz29k327/ELy6UFcmbiZNOsinaKvzv16WZR0P6etfSWYzE47C4/56B3Uw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
@@ -15144,7 +15144,7 @@
         "cacache": "17.1.3",
         "chokidar": "3.5.3",
         "copy-webpack-plugin": "11.0.0",
-        "critters": "0.0.19",
+        "critters": "0.0.20",
         "css-loader": "6.8.1",
         "esbuild": "0.17.19",
         "esbuild-wasm": "0.17.19",
@@ -19889,9 +19889,9 @@
       }
     },
     "critters": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/critters/-/critters-0.0.19.tgz",
-      "integrity": "sha512-Fm4ZAXsG0VzWy1U30rP4qxbaWGSsqXDgSupJW1OUJGDAs0KWC+j37v7p5a2kZ9BPJvhRzWm3be+Hc9WvQOBUOw==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/critters/-/critters-0.0.20.tgz",
+      "integrity": "sha512-CImNRorKOl5d8TWcnAz5n5izQ6HFsvz29k327/ELy6UFcmbiZNOsinaKvzv16WZR0P6etfSWYzE47C4/56B3Uw==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",


### PR DESCRIPTION
Nur eine Kleinigkeit. Aber wir wollen ja sicher sein. In der Empfehlung stand, dass man ein Update des Pakets einfach durchführen kann. Keine breaking changes.